### PR TITLE
Prefix Prefill Support for GeForce GTX

### DIFF
--- a/gtx/v0.8.5/Dockerfile.gtx
+++ b/gtx/v0.8.5/Dockerfile.gtx
@@ -1,0 +1,8 @@
+FROM ghcr.io/sasha0552/vllm:v0.8.5
+
+# patch for gtx 1070 compat with 48k shared_memory and compute capacity 6,1
+WORKDIR /vllm-workspace
+COPY pascal-gtx-prefill.patch .
+RUN cd /usr/local/lib/python3.12/dist-packages/vllm/attention/ops && \
+  git apply /vllm-workspace/pascal-gtx-prefill.patch && \
+  rm /vllm-workspace/pascal-gtx-prefill.patch

--- a/gtx/v0.8.5/pascal-gtx-prefill.patch
+++ b/gtx/v0.8.5/pascal-gtx-prefill.patch
@@ -1,0 +1,45 @@
+diff --git a/prefix_prefill.py b/prefix_prefill.py
+index 5bbe82bb..523afc11 100644
+--- a/prefix_prefill.py
++++ b/prefix_prefill.py
+@@ -9,9 +9,14 @@ import triton.language as tl
+ 
+ from vllm.platforms import current_platform
+ 
++# Determine if we're running a consumer-grade card
++IS_GTX = "GeForce GTX" in current_platform.get_device_name()
++
+ # Static kernels parameters
+ if current_platform.get_device_capability() == (6, 0):  # P100 has 24 KB SM
+     BASE_BLOCK = 16
++elif current_platform.get_device_capability() == (6, 1) and IS_GTX:  # GTX 1070 has 24 KB SM
++    BASE_BLOCK = 16
+ elif current_platform.get_device_capability() == (6, 1):  # P40 has 48 KB SM
+     BASE_BLOCK = 32
+ elif not current_platform.has_device_capability(80):
+@@ -855,6 +860,14 @@ def context_attention_fwd(q,
+ 
+     grid = lambda META: (batch, head,
+                          triton.cdiv(max_input_len, META["BLOCK_M"]))
++
++    if IS_GTX:
++        block_m = BASE_BLOCK * 2
++        block_n = BASE_BLOCK
++    else:
++        block_m = 128
++        block_n = 64
++
+     _fwd_kernel[grid](
+         q,
+         k,
+@@ -900,8 +913,8 @@ def context_attention_fwd(q,
+         BLOCK_DMODEL_PADDED=Lk_padded,
+         SLIDING_WINDOW=sliding_window,
+         SKIP_DECODE=skip_decode,
+-        BLOCK_M=128,
+-        BLOCK_N=64,
++        BLOCK_M=block_m,
++        BLOCK_N=block_n,
+         num_unroll_cache=4,
+         num_unroll_request=1,
+         num_warps=4,


### PR DESCRIPTION
Hi!

Thanks for this awesome repo!

Opening this in case there's any interest in supporting more features on consumer grade cards. I totally understand if there isn't, but it's an interesting niche because the GTX 1070 was one of the most cost-effective cards at the height of the 2017 crypto mining boom and thus more than a few folks have a lot of them lying around looking to be repurposed.

If there is, then this patch included here could be worked into the repo in a much better way - the patch organization here is very thorough. This is just an example since you can build this container without rebuilding vllm at all, which is great for testing.

I've tested this with two 1070s running with `--pipeline-parallel-size=2`, enforcing prefix caching with `--enable-prefix-caching` explicitly. Without this patch, the block size selected based on the compute capacity is too large for the cards, causing triton to throw:

```sh
triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 65536, Hardware limit: 49152. Reducing block sizes or `num_stages` may help.
```

Cheers