### PR TITLE
Fake Flash Attention Wrapper.

### DIFF
--- a/fake_flash_attn/README.txt
+++ b/fake_flash_attn/README.txt
@@ -1,0 +1,4 @@
+A Wrapper to Install when your GPU does not support flash attention.
+It will mimick flash attention.
+
+NOTE This needs more work by someone who know GPU Programming

--- a/fake_flash_attn/flash_attn/__init__.py
+++ b/fake_flash_attn/flash_attn/__init__.py
@@ -3,8 +3,5 @@ from .modules.mha import FlashAttention
 from .flash_attn_interface import (
     _flash_attn_forward,
     _flash_attn_backward,
-    flash_attn_unpadded_func,
-    _flash_attn_varlen_forward,   # Add this
-    _flash_attn_varlen_backward,   # Add this
-    flash_attn_varlen_func         # Add this
+    flash_attn_unpadded_func as flash_attn_varlen_func,
 )

--- a/fake_flash_attn/flash_attn/__init__.py
+++ b/fake_flash_attn/flash_attn/__init__.py
@@ -1,0 +1,10 @@
+from .flash_attention import flash_attn_func
+from .modules.mha import FlashAttention
+from .flash_attn_interface import (
+    _flash_attn_forward,
+    _flash_attn_backward,
+    flash_attn_unpadded_func,
+    _flash_attn_varlen_forward,   # Add this
+    _flash_attn_varlen_backward,   # Add this
+    flash_attn_varlen_func         # Add this
+)

--- a/fake_flash_attn/flash_attn/flash_attention.py
+++ b/fake_flash_attn/flash_attn/flash_attention.py
@@ -2,6 +2,8 @@ import torch
 import math
 from typing import Optional, Tuple
 from torch.nn import functional as F
+from torch.utils.checkpoint import checkpoint
+import torch.cuda
 
 def flash_attn_func(
     q: torch.Tensor,
@@ -17,123 +19,35 @@ def flash_attn_func(
     # Ignore unimplemented arguments
     if window_size != (-1, -1):
         print("Warning: window_size not implemented - using full attention")
-    
+
     batch_size, q_seqlen, num_heads, head_dim = q.shape
     k_seqlen = k.size(1)
-    
-    # Determine if we can use optimized kernels
-    use_optimized = False
-    if hasattr(F, 'scaled_dot_product_attention'):
-        # Check GPU compatibility
-        major, minor = torch.cuda.get_device_capability()
-        compute_capability = major * 10 + minor
-        
-        # Check dtype compatibility
-        dtype_supported = q.dtype in [torch.float16, torch.float32]
-        
-        # Only use optimized path for supported GPUs and dtypes
-        if compute_capability >= 80 and dtype_supported and q_seqlen <= 2048 and k_seqlen <= 2048:
-            use_optimized = True
-    
-    if use_optimized:
-        # Rearrange to [batch, heads, seqlen, dim]
-        q_t = q.transpose(1, 2)
-        k_t = k.transpose(1, 2)
-        v_t = v.transpose(1, 2)
-        
-        # Compute scale value
-        scale_val = softmax_scale if softmax_scale is not None else (1.0 / math.sqrt(head_dim))
-        
-        # Use the most efficient available kernel
-        with torch.backends.cuda.sdp_kernel(enable_flash=True, enable_mem_efficient=True, enable_math=True):
-            context = F.scaled_dot_product_attention(
-                q_t, k_t, v_t,
-                attn_mask=None,
-                dropout_p=dropout_p if torch.is_grad_enabled() else 0.0,
-                is_causal=causal,
-                scale=scale_val
-            )
-        
-        # Rearrange back to [batch, seqlen, heads, dim]
-        context = context.transpose(1, 2).contiguous()
-        
-        if return_attn_probs:
-            print("Warning: return_attn_probs=True not supported with optimized attention")
-            return context, None
-        return context
-    
-    # For unsupported configurations, use memory-efficient chunked attention
-    # Auto-tune chunk sizes based on available memory
-    if torch.cuda.is_available():
-        free_mem, _ = torch.cuda.mem_get_info()
-        available_mem = free_mem * 0.5  # Use 50% of free memory
-        # Calculate chunk sizes based on memory requirements
-        divisor = batch_size * num_heads * head_dim * 4
-        if divisor > 0:
-            q_chunk_size = max(8, min(64, int((available_mem / divisor) ** 0.5)))
-            k_chunk_size = max(64, min(512, q_chunk_size * 8))
-        else:
-            # Fallback to safe values
-            q_chunk_size = 16
-            k_chunk_size = 128
-    else:
-        # CPU fallback
-        q_chunk_size = 16
-        k_chunk_size = 128
-    
-    # Rearrange to [batch, heads, seqlen, dim]
-    q = q.transpose(1, 2).contiguous()
-    k = k.transpose(1, 2).contiguous()
-    v = v.transpose(1, 2).contiguous()
-    
+
+    # Ensure contiguous memory layout after permutation
+    q = q.permute(0, 2, 1, 3).contiguous()
+    k = k.permute(0, 2, 1, 3).contiguous()
+    v = v.permute(0, 2, 1, 3).contiguous()
+
     output = torch.zeros_like(q)
-    scale_val = softmax_scale if softmax_scale is not None else (1.0 / math.sqrt(head_dim))
-    
-    # Precompute causal mask if needed
-    if causal:
-        full_mask = torch.triu(
-            torch.full((q_seqlen, k_seqlen), float('-inf'), device=q.device),
-            diagonal=1
+
+    # Use math.sqrt with float conversion for better numerical stability
+    scale = softmax_scale if softmax_scale is not None else (1.0 / math.sqrt(float(head_dim)))
+
+    # Use PyTorch's built-in scaled_dot_product_attention for CUDA acceleration
+    with torch.cuda.amp.autocast():
+        # F.scaled_dot_product_attention handles causal masking, softmax, dropout, and V multiplication
+        output = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=dropout_p if dropout_p > 0.0 and torch.is_grad_enabled() else 0.0,
+            is_causal=causal,
         )
-    
-    # Process query chunks
-    for q_start in range(0, q_seqlen, q_chunk_size):
-        q_end = min(q_start + q_chunk_size, q_seqlen)
-        q_chunk = q[:, :, q_start:q_end]
-        
-        # Initialize output for this chunk
-        chunk_output = torch.zeros_like(q_chunk)
-        
-        # Process key chunks
-        for k_start in range(0, k_seqlen, k_chunk_size):
-            k_end = min(k_start + k_chunk_size, k_seqlen)
-            k_chunk = k[:, :, k_start:k_end]
-            v_chunk = v[:, :, k_start:k_end]
-            
-            # Compute scores for this chunk
-            scores = torch.matmul(q_chunk, k_chunk.transpose(-1, -2)) * scale_val
-            
-            # Apply causal mask if needed
-            if causal:
-                # Use precomputed mask for the current chunks
-                mask_chunk = full_mask[q_start:q_end, k_start:k_end]
-                scores = scores + mask_chunk.unsqueeze(0).unsqueeze(0)
-            
-            # Compute attention weights for this chunk
-            attn_weights = torch.softmax(scores, dim=-1)
-            
-            if dropout_p > 0.0 and torch.is_grad_enabled():
-                attn_weights = F.dropout(attn_weights, p=dropout_p)
-            
-            # Compute context chunk
-            context_chunk = torch.matmul(attn_weights, v_chunk)
-            chunk_output = chunk_output + context_chunk
-        
-        output[:, :, q_start:q_end] = chunk_output
-    
+
     # Rearrange back to [batch, seqlen, heads, dim]
-    output = output.transpose(1, 2).contiguous()
-    
+    output = output.permute(0, 2, 1, 3)
+
     if return_attn_probs:
         print("Warning: return_attn_probs=True not supported with chunked attention")
         return output, None

--- a/fake_flash_attn/flash_attn/flash_attention.py
+++ b/fake_flash_attn/flash_attn/flash_attention.py
@@ -1,0 +1,140 @@
+import torch
+import math
+from typing import Optional, Tuple
+from torch.nn import functional as F
+
+def flash_attn_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    dropout_p: float = 0.0,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[int, int] = (-1, -1),
+    return_attn_probs: bool = False,
+    **kwargs
+) -> torch.Tensor:
+    # Ignore unimplemented arguments
+    if window_size != (-1, -1):
+        print("Warning: window_size not implemented - using full attention")
+    
+    batch_size, q_seqlen, num_heads, head_dim = q.shape
+    k_seqlen = k.size(1)
+    
+    # Determine if we can use optimized kernels
+    use_optimized = False
+    if hasattr(F, 'scaled_dot_product_attention'):
+        # Check GPU compatibility
+        major, minor = torch.cuda.get_device_capability()
+        compute_capability = major * 10 + minor
+        
+        # Check dtype compatibility
+        dtype_supported = q.dtype in [torch.float16, torch.float32]
+        
+        # Only use optimized path for supported GPUs and dtypes
+        if compute_capability >= 80 and dtype_supported and q_seqlen <= 2048 and k_seqlen <= 2048:
+            use_optimized = True
+    
+    if use_optimized:
+        # Rearrange to [batch, heads, seqlen, dim]
+        q_t = q.transpose(1, 2)
+        k_t = k.transpose(1, 2)
+        v_t = v.transpose(1, 2)
+        
+        # Compute scale value
+        scale_val = softmax_scale if softmax_scale is not None else (1.0 / math.sqrt(head_dim))
+        
+        # Use the most efficient available kernel
+        with torch.backends.cuda.sdp_kernel(enable_flash=True, enable_mem_efficient=True, enable_math=True):
+            context = F.scaled_dot_product_attention(
+                q_t, k_t, v_t,
+                attn_mask=None,
+                dropout_p=dropout_p if torch.is_grad_enabled() else 0.0,
+                is_causal=causal,
+                scale=scale_val
+            )
+        
+        # Rearrange back to [batch, seqlen, heads, dim]
+        context = context.transpose(1, 2).contiguous()
+        
+        if return_attn_probs:
+            print("Warning: return_attn_probs=True not supported with optimized attention")
+            return context, None
+        return context
+    
+    # For unsupported configurations, use memory-efficient chunked attention
+    # Auto-tune chunk sizes based on available memory
+    if torch.cuda.is_available():
+        free_mem, _ = torch.cuda.mem_get_info()
+        available_mem = free_mem * 0.5  # Use 50% of free memory
+        # Calculate chunk sizes based on memory requirements
+        divisor = batch_size * num_heads * head_dim * 4
+        if divisor > 0:
+            q_chunk_size = max(8, min(64, int((available_mem / divisor) ** 0.5)))
+            k_chunk_size = max(64, min(512, q_chunk_size * 8))
+        else:
+            # Fallback to safe values
+            q_chunk_size = 16
+            k_chunk_size = 128
+    else:
+        # CPU fallback
+        q_chunk_size = 16
+        k_chunk_size = 128
+    
+    # Rearrange to [batch, heads, seqlen, dim]
+    q = q.transpose(1, 2).contiguous()
+    k = k.transpose(1, 2).contiguous()
+    v = v.transpose(1, 2).contiguous()
+    
+    output = torch.zeros_like(q)
+    scale_val = softmax_scale if softmax_scale is not None else (1.0 / math.sqrt(head_dim))
+    
+    # Precompute causal mask if needed
+    if causal:
+        full_mask = torch.triu(
+            torch.full((q_seqlen, k_seqlen), float('-inf'), device=q.device),
+            diagonal=1
+        )
+    
+    # Process query chunks
+    for q_start in range(0, q_seqlen, q_chunk_size):
+        q_end = min(q_start + q_chunk_size, q_seqlen)
+        q_chunk = q[:, :, q_start:q_end]
+        
+        # Initialize output for this chunk
+        chunk_output = torch.zeros_like(q_chunk)
+        
+        # Process key chunks
+        for k_start in range(0, k_seqlen, k_chunk_size):
+            k_end = min(k_start + k_chunk_size, k_seqlen)
+            k_chunk = k[:, :, k_start:k_end]
+            v_chunk = v[:, :, k_start:k_end]
+            
+            # Compute scores for this chunk
+            scores = torch.matmul(q_chunk, k_chunk.transpose(-1, -2)) * scale_val
+            
+            # Apply causal mask if needed
+            if causal:
+                # Use precomputed mask for the current chunks
+                mask_chunk = full_mask[q_start:q_end, k_start:k_end]
+                scores = scores + mask_chunk.unsqueeze(0).unsqueeze(0)
+            
+            # Compute attention weights for this chunk
+            attn_weights = torch.softmax(scores, dim=-1)
+            
+            if dropout_p > 0.0 and torch.is_grad_enabled():
+                attn_weights = F.dropout(attn_weights, p=dropout_p)
+            
+            # Compute context chunk
+            context_chunk = torch.matmul(attn_weights, v_chunk)
+            chunk_output = chunk_output + context_chunk
+        
+        output[:, :, q_start:q_end] = chunk_output
+    
+    # Rearrange back to [batch, seqlen, heads, dim]
+    output = output.transpose(1, 2).contiguous()
+    
+    if return_attn_probs:
+        print("Warning: return_attn_probs=True not supported with chunked attention")
+        return output, None
+    return output

--- a/fake_flash_attn/flash_attn/flash_attn_interface.py
+++ b/fake_flash_attn/flash_attn/flash_attn_interface.py
@@ -1,0 +1,133 @@
+import torch  # IMPORT ADDED HERE
+import math
+from typing import Optional, Tuple
+from .flash_attention import flash_attn_func
+
+def _flash_attn_forward(*args, **kwargs):
+    raise NotImplementedError("_flash_attn_forward is not implemented in fake_flash_attn")
+
+def _flash_attn_backward(*args, **kwargs):
+    raise NotImplementedError("_flash_attn_backward is not implemented in fake_flash_attn")
+
+def flash_attn_unpadded_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    return_attn_probs: bool = False,
+    **kwargs
+) -> torch.Tensor:
+    # Convert unpadded to padded format
+    batch_size = len(cu_seqlens_q) - 1
+    num_heads = q.shape[1]
+    head_dim = q.shape[2]
+    
+    q_padded = torch.zeros((batch_size, max_seqlen_q, num_heads, head_dim), device=q.device, dtype=q.dtype)
+    k_padded = torch.zeros((batch_size, max_seqlen_k, num_heads, head_dim), device=k.device, dtype=k.dtype)
+    v_padded = torch.zeros((batch_size, max_seqlen_k, num_heads, head_dim), device=v.device, dtype=v.dtype)
+    
+    for i in range(batch_size):
+        q_start = cu_seqlens_q[i]
+        q_end = cu_seqlens_q[i+1]
+        k_start = cu_seqlens_k[i]
+        k_end = cu_seqlens_k[i+1]
+        
+        q_padded[i, :q_end-q_start] = q[q_start:q_end]
+        k_padded[i, :k_end-k_start] = k[k_start:k_end]
+        v_padded[i, :k_end-k_start] = v[k_start:k_end]
+    
+    # Use our vanilla attention function
+    result = flash_attn_func(
+        q_padded, k_padded, v_padded,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        return_attn_probs=return_attn_probs,
+        **kwargs
+    )
+    
+    # Convert back to unpadded format if needed
+    if return_attn_probs:
+        output, attn_probs = result
+        output_unpadded = torch.zeros_like(q)
+        for i in range(batch_size):
+            q_start = cu_seqlens_q[i]
+            q_end = cu_seqlens_q[i+1]
+            output_unpadded[q_start:q_end] = output[i, :q_end-q_start]
+        return output_unpadded, None, attn_probs
+    else:
+        output_unpadded = torch.zeros_like(q)
+        for i in range(batch_size):
+            q_start = cu_seqlens_q[i]
+            q_end = cu_seqlens_q[i+1]
+            output_unpadded[q_start:q_end] = result[i, :q_end-q_start]
+        return output_unpadded
+
+def _flash_attn_varlen_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float,
+    softmax_scale: float,
+    causal: bool,
+    window_size: Tuple[int, int],
+    alibi_slopes: Optional[torch.Tensor],
+    deterministic: bool,
+    return_attn_probs: bool,
+    **kwargs
+) -> torch.Tensor:
+    # For now, use our unpadded implementation
+    print("Warning: Using fallback implementation for _flash_attn_varlen_forward")
+    return flash_attn_unpadded_func(
+        q, k, v,
+        cu_seqlens_q, cu_seqlens_k,
+        max_seqlen_q, max_seqlen_k,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        return_attn_probs=return_attn_probs,
+        **kwargs
+    )
+
+def _flash_attn_varlen_backward(*args, **kwargs):
+    raise NotImplementedError("_flash_attn_varlen_backward is not implemented in fake_flash_attn")
+
+def flash_attn_varlen_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float = 0.0,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[int, int] = (-1, -1),
+    alibi_slopes: Optional[torch.Tensor] = None,
+    deterministic: bool = False,
+    return_attn_probs: bool = False,
+    **kwargs
+) -> torch.Tensor:
+    # For now, use our unpadded implementation
+    print("Warning: Using fallback implementation for flash_attn_varlen_func")
+    return flash_attn_unpadded_func(
+        q, k, v,
+        cu_seqlens_q, cu_seqlens_k,
+        max_seqlen_q, max_seqlen_k,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        return_attn_probs=return_attn_probs,
+        **kwargs
+    )

--- a/fake_flash_attn/flash_attn/flash_attn_interface.py
+++ b/fake_flash_attn/flash_attn/flash_attn_interface.py
@@ -1,13 +1,50 @@
-import torch  # IMPORT ADDED HERE
+import torch
 import math
 from typing import Optional, Tuple
 from .flash_attention import flash_attn_func
+import torch.cuda
 
 def _flash_attn_forward(*args, **kwargs):
-    raise NotImplementedError("_flash_attn_forward is not implemented in fake_flash_attn")
+    # Adapt args to match our flash_attn_func signature
+    q, k, v = args[0], args[1], args[2]
+    dropout_p = kwargs.get('dropout_p', 0.0)
+    softmax_scale = kwargs.get('softmax_scale', None)
+    causal = kwargs.get('causal', False)
+    window_size = kwargs.get('window_size', (-1, -1))
+    return_attn_probs = kwargs.get('return_attn_probs', False)
+    
+    # Use our optimized attention function
+    with torch.cuda.amp.autocast():
+        return flash_attn_func(
+            q, k, v,
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            return_attn_probs=return_attn_probs
+        )
 
 def _flash_attn_backward(*args, **kwargs):
-    raise NotImplementedError("_flash_attn_backward is not implemented in fake_flash_attn")
+    # For Pascal GPUs, use gradient checkpointing for memory efficiency
+    grad_out, q, k, v, out = args[0], args[1], args[2], args[3], args[4]
+    
+    # Clone inputs for gradient computation
+    q = q.clone().detach().requires_grad_(True)
+    k = k.clone().detach().requires_grad_(True)
+    v = v.clone().detach().requires_grad_(True)
+    
+    # Recompute forward pass with AMP disabled for gradient calculation
+    with torch.cuda.amp.autocast(False):
+        output = flash_attn_func(q, k, v, **kwargs)
+    
+    # Compute gradients
+    grad_q, grad_k, grad_v = torch.autograd.grad(
+        outputs=output,
+        inputs=(q, k, v),
+        grad_outputs=grad_out
+    )
+    
+    return grad_q, grad_k, grad_v
 
 def flash_attn_unpadded_func(
     q: torch.Tensor,
@@ -23,111 +60,36 @@ def flash_attn_unpadded_func(
     return_attn_probs: bool = False,
     **kwargs
 ) -> torch.Tensor:
-    # Convert unpadded to padded format
     batch_size = len(cu_seqlens_q) - 1
     num_heads = q.shape[1]
     head_dim = q.shape[2]
-    
-    q_padded = torch.zeros((batch_size, max_seqlen_q, num_heads, head_dim), device=q.device, dtype=q.dtype)
-    k_padded = torch.zeros((batch_size, max_seqlen_k, num_heads, head_dim), device=k.device, dtype=k.dtype)
-    v_padded = torch.zeros((batch_size, max_seqlen_k, num_heads, head_dim), device=v.device, dtype=v.dtype)
-    
+
+    # Preallocate output
+    output_unpadded = torch.zeros_like(q)
+
+    # Vectorized batch processing
     for i in range(batch_size):
         q_start = cu_seqlens_q[i]
         q_end = cu_seqlens_q[i+1]
         k_start = cu_seqlens_k[i]
         k_end = cu_seqlens_k[i+1]
-        
-        q_padded[i, :q_end-q_start] = q[q_start:q_end]
-        k_padded[i, :k_end-k_start] = k[k_start:k_end]
-        v_padded[i, :k_end-k_start] = v[k_start:k_end]
-    
-    # Use our vanilla attention function
-    result = flash_attn_func(
-        q_padded, k_padded, v_padded,
-        dropout_p=dropout_p,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        return_attn_probs=return_attn_probs,
-        **kwargs
-    )
-    
-    # Convert back to unpadded format if needed
-    if return_attn_probs:
-        output, attn_probs = result
-        output_unpadded = torch.zeros_like(q)
-        for i in range(batch_size):
-            q_start = cu_seqlens_q[i]
-            q_end = cu_seqlens_q[i+1]
-            output_unpadded[q_start:q_end] = output[i, :q_end-q_start]
-        return output_unpadded, None, attn_probs
-    else:
-        output_unpadded = torch.zeros_like(q)
-        for i in range(batch_size):
-            q_start = cu_seqlens_q[i]
-            q_end = cu_seqlens_q[i+1]
-            output_unpadded[q_start:q_end] = result[i, :q_end-q_start]
-        return output_unpadded
 
-def _flash_attn_varlen_forward(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    dropout_p: float,
-    softmax_scale: float,
-    causal: bool,
-    window_size: Tuple[int, int],
-    alibi_slopes: Optional[torch.Tensor],
-    deterministic: bool,
-    return_attn_probs: bool,
-    **kwargs
-) -> torch.Tensor:
-    # For now, use our unpadded implementation
-    print("Warning: Using fallback implementation for _flash_attn_varlen_forward")
-    return flash_attn_unpadded_func(
-        q, k, v,
-        cu_seqlens_q, cu_seqlens_k,
-        max_seqlen_q, max_seqlen_k,
-        dropout_p=dropout_p,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        return_attn_probs=return_attn_probs,
-        **kwargs
-    )
+        q_batch = q[q_start:q_end]
+        k_batch = k[k_start:k_end]
+        v_batch = v[k_start:k_end]
 
-def _flash_attn_varlen_backward(*args, **kwargs):
-    raise NotImplementedError("_flash_attn_varlen_backward is not implemented in fake_flash_attn")
+        # Use our optimized attention function
+        with torch.cuda.amp.autocast():
+            result = flash_attn_func(
+                q_batch.unsqueeze(0).half(), k_batch.unsqueeze(0).half(), v_batch.unsqueeze(0).half(),
+                dropout_p=dropout_p,
+                softmax_scale=softmax_scale,
+                causal=causal,
+                return_attn_probs=return_attn_probs,
+                **kwargs
+            )
 
-def flash_attn_varlen_func(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    dropout_p: float = 0.0,
-    softmax_scale: Optional[float] = None,
-    causal: bool = False,
-    window_size: Tuple[int, int] = (-1, -1),
-    alibi_slopes: Optional[torch.Tensor] = None,
-    deterministic: bool = False,
-    return_attn_probs: bool = False,
-    **kwargs
-) -> torch.Tensor:
-    # For now, use our unpadded implementation
-    print("Warning: Using fallback implementation for flash_attn_varlen_func")
-    return flash_attn_unpadded_func(
-        q, k, v,
-        cu_seqlens_q, cu_seqlens_k,
-        max_seqlen_q, max_seqlen_k,
-        dropout_p=dropout_p,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        return_attn_probs=return_attn_probs,
-        **kwargs
-    )
+        # Copy result back to output
+        output_unpadded[q_start:q_end] = result[0, :q_end - q_start]
+
+    return output_unpadded

--- a/fake_flash_attn/flash_attn/modules/__init__.py
+++ b/fake_flash_attn/flash_attn/modules/__init__.py
@@ -1,0 +1,1 @@
+from .mha import FlashAttention

--- a/fake_flash_attn/flash_attn/modules/mha.py
+++ b/fake_flash_attn/flash_attn/modules/mha.py
@@ -1,6 +1,8 @@
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 from flash_attn.flash_attention import flash_attn_func
+import torch.cuda.amp
 
 class FlashAttention(nn.Module):
     def __init__(self, *args, **kwargs):
@@ -14,4 +16,5 @@ class FlashAttention(nn.Module):
         v: torch.Tensor,
         **kwargs
     ) -> torch.Tensor:
-        return flash_attn_func(q, k, v, **kwargs)
+        with torch.cuda.amp.autocast():
+            return F.scaled_dot_product_attention(q, k, v, dropout_p=kwargs.get('dropout_p', 0.0), is_causal=kwargs.get('causal', False))

--- a/fake_flash_attn/flash_attn/modules/mha.py
+++ b/fake_flash_attn/flash_attn/modules/mha.py
@@ -1,0 +1,17 @@
+import torch
+import torch.nn as nn
+from flash_attn.flash_attention import flash_attn_func
+
+class FlashAttention(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        # Ignore original arguments since we're using vanilla attention
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        **kwargs
+    ) -> torch.Tensor:
+        return flash_attn_func(q, k, v, **kwargs)

--- a/fake_flash_attn/setup.py
+++ b/fake_flash_attn/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="fake_flash_attn",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=["torch"],
+)


### PR DESCRIPTION
This is a wrapper you can use for Older GPU's that do not support flash Attention.

Install instead of the standard flash attention

It works when I use it with my Tesla P40 but could do with some tuning by those knowledgeable about GPU Programming 

Install
cd fake_flash_attn
pip install -e .


Test 
python
import torch
from flash_attn import flash_attn_func

q = torch.randn(1, 16, 8, 64).cuda()
k = torch.randn(1, 16, 8, 64).cuda()
v = torch.randn(1, 16, 8, 64).cuda()

output = flash_attn_func(q, k, v, causal=True)
print(output.shape)  # Should be torch.Size([1, 16, 8, 64])
